### PR TITLE
Remove enumerator for Size, make it a data class and configurable

### DIFF
--- a/app/src/main/java/nl/dionsegijn/konfettidemo/MainActivity.kt
+++ b/app/src/main/java/nl/dionsegijn/konfettidemo/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                 .setFadeOutEnabled(true)
                 .setTimeToLive(config.timeToLive)
                 .addShapes(*config.shapes)
-                .addSizes(Size(35f), Size(45f, 6f))
+                .addSizes(Size(12), Size(16, 6f))
                 .setPosition(-50f, viewKonfetti.width + 50f, -50f, -50f)
                 .stream(300, 5000L)
     }
@@ -104,7 +104,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                 .setFadeOutEnabled(true)
                 .setTimeToLive(config.timeToLive)
                 .addShapes(*config.shapes)
-                .addSizes(Size(35f), Size(45f, 6f))
+                .addSizes(Size(12), Size(16, 6f))
                 .setPosition(viewKonfetti.x + viewKonfetti.width / 2, viewKonfetti.y + viewKonfetti.height / 3)
                 .burst(100)
     }
@@ -139,7 +139,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                             .setDirection(degrees - 50, degrees + 50)
                             .setSpeed(0f, speed + 5f)
                             .addShapes(Shape.RECT, Shape.CIRCLE)
-                            .addSizes(Size(35f), Size(45f, 6f))
+                            .addSizes(Size(12), Size(16, 6f))
                             .setPosition(startX, startY)
                             .setTimeToLive(10000)
                             .setFadeOutEnabled(true)

--- a/app/src/main/java/nl/dionsegijn/konfettidemo/MainActivity.kt
+++ b/app/src/main/java/nl/dionsegijn/konfettidemo/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                 .setFadeOutEnabled(true)
                 .setTimeToLive(config.timeToLive)
                 .addShapes(*config.shapes)
-                .addSizes(Size.SMALL)
+                .addSizes(Size(35f), Size(45f, 6f))
                 .setPosition(-50f, viewKonfetti.width + 50f, -50f, -50f)
                 .stream(300, 5000L)
     }
@@ -104,7 +104,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                 .setFadeOutEnabled(true)
                 .setTimeToLive(config.timeToLive)
                 .addShapes(*config.shapes)
-                .addSizes(Size.SMALL)
+                .addSizes(Size(35f), Size(45f, 6f))
                 .setPosition(viewKonfetti.x + viewKonfetti.width / 2, viewKonfetti.y + viewKonfetti.height / 3)
                 .burst(100)
     }
@@ -139,7 +139,7 @@ class MainActivity : AppCompatActivity(), OnConfigurationChangedListener {
                             .setDirection(degrees - 50, degrees + 50)
                             .setSpeed(0f, speed + 5f)
                             .addShapes(Shape.RECT, Shape.CIRCLE)
-                            .addSizes(Size.SMALL)
+                            .addSizes(Size(35f), Size(45f, 6f))
                             .setPosition(startX, startY)
                             .setTimeToLive(10000)
                             .setFadeOutEnabled(true)

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -1,11 +1,13 @@
 package nl.dionsegijn.konfetti
 
+import android.content.res.Resources
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import nl.dionsegijn.konfetti.models.Shape
 import nl.dionsegijn.konfetti.models.Size
 import nl.dionsegijn.konfetti.models.Vector
+import nl.dionsegijn.konfetti.models.sizeDp
 import java.util.*
 
 class Confetti(var location: Vector,
@@ -18,7 +20,7 @@ class Confetti(var location: Vector,
                var velocity: Vector = Vector()) {
 
     private val mass = size.mass
-    private var width = size.size
+    private var width = size.sizeDp.toFloat()
     private val paint: Paint = Paint()
 
     private var rotationSpeed = 1f
@@ -31,8 +33,10 @@ class Confetti(var location: Vector,
     private var alpha: Int = 255
 
     init {
+        val minRotationSpeed = 0.29f * Resources.getSystem().displayMetrics.density
+        val maxRotationSpeed = minRotationSpeed * 3
+        rotationSpeed = maxRotationSpeed * Random().nextFloat() + minRotationSpeed
         paint.color = color
-        rotationSpeed = 3 * Random().nextFloat() + 1
     }
 
     fun getSize(): Float {
@@ -62,7 +66,7 @@ class Confetti(var location: Vector,
         location.add(v)
 
 
-        if(lifespan <= 0) updateAlpha(deltaTime)
+        if (lifespan <= 0) updateAlpha(deltaTime)
         else lifespan -= (deltaTime * 1000).toLong()
 
         val rSpeed = (rotationSpeed * deltaTime) * speedF
@@ -74,9 +78,9 @@ class Confetti(var location: Vector,
     }
 
     fun updateAlpha(deltaTime: Float) {
-        if(fadeOut) {
+        if (fadeOut) {
             val interval = 5 * deltaTime * speedF
-            if(alpha - interval < 0) alpha = 0
+            if (alpha - interval < 0) alpha = 0
             else alpha -= (5 * deltaTime * speedF).toInt()
         } else {
             alpha = 0
@@ -85,7 +89,7 @@ class Confetti(var location: Vector,
 
     fun display(canvas: Canvas) {
         // if the particle is outside the bottom of the view the lifetime is over.
-        if(location.y > canvas.height) {
+        if (location.y > canvas.height) {
             lifespan = 0
             return
         }
@@ -99,7 +103,7 @@ class Confetti(var location: Vector,
         var right = location.x + rotationWidth
         /** Switch values. Left or right may not be negative due to how Android Api < 25
          *  draws Rect and RectF, negative values won't be drawn resulting in flickering confetti */
-        if(left > right) {
+        if (left > right) {
             left += right
             right = left - right
             left -= right

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -25,7 +25,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
 
     /** Default values */
     private var colors = intArrayOf(Color.RED)
-    private var sizes = arrayOf(Size(40f))
+    private var sizes = arrayOf(Size(16))
     private var shapes = arrayOf(Shape.RECT)
     private var confettiConfig = ConfettiConfig()
 
@@ -67,7 +67,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
     }
 
     /**
-     * Add one or more different sizes by defining a [Size] in pixels and optionally its mass
+     * Add one or more different sizes by defining a [Size] in dip and optionally its mass
      */
     fun addSizes(vararg possibleSizes: Size): ParticleSystem {
         this.sizes = possibleSizes.filterIsInstance<Size>().toTypedArray()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -25,7 +25,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
 
     /** Default values */
     private var colors = intArrayOf(Color.RED)
-    private var sizes = arrayOf(Size.SMALL)
+    private var sizes = arrayOf(Size(40f))
     private var shapes = arrayOf(Shape.RECT)
     private var confettiConfig = ConfettiConfig()
 
@@ -67,8 +67,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
     }
 
     /**
-     * Configure one or more sizes predefined in [Size].
-     * Default size is [Size.SMALL]
+     * Add one or more different sizes by defining a [Size] in pixels and optionally its mass
      */
     fun addSizes(vararg possibleSizes: Size): ParticleSystem {
         this.sizes = possibleSizes.filterIsInstance<Size>().toTypedArray()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
@@ -2,11 +2,7 @@ package nl.dionsegijn.konfetti.models
 
 /**
  * Created by dionsegijn on 3/26/17.
- * [size] the size of the confetti in size
+ * [size] the size of the confetti in pixels
  * [mass] each size has its own mass for slightly different behavior
  */
-enum class Size(val size: Float, val mass: Float) {
-    SMALL(40f, 5f),
-    MEDIUM(60f, 10f),
-    LARGE(80f, 15f)
-}
+data class Size(val size: Float, val mass: Float = 5f)

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
@@ -1,8 +1,13 @@
 package nl.dionsegijn.konfetti.models
 
+import android.content.res.Resources
+
 /**
  * Created by dionsegijn on 3/26/17.
- * [size] the size of the confetti in pixels
- * [mass] each size has its own mass for slightly different behavior
+ * [size] the size of the confetti in dip
+ * [mass] each size can have its own mass for slightly different behavior
  */
-data class Size(val size: Float, val mass: Float = 5f)
+data class Size(val size: Int, val mass: Float = 5f)
+
+val Size.sizeDp: Int
+    get() = (this.size * Resources.getSystem().displayMetrics.density).toInt()


### PR DESCRIPTION
Changed the enumerator to a data class so many more sizes can be supported. Konfetti doesn't take pixel density into account. Size has a default mass which is also configurable.

- [x] Use dip instead pixels for the size