### PR TITLE
Deprecate stream function taking particlesPerSecond, emittingTime and maxParticles as parameters

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -189,24 +189,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
         start()
     }
 
-    /**
-     * Emit a certain amount of particles per second
-     * calling this function will start the system rendering the confetti
-     * [particlesPerSecond] amount of particles created per second
-     * [emittingTime] max amount of time to emit in milliseconds
-     * [maxParticles] max amount of particles to emit
-     */
-    fun stream(particlesPerSecond: Int, emittingTime: Long, maxParticles: Int) {
-        emitter = StreamEmitter(location, velocity, sizes, shapes, colors, confettiConfig).emit(
-                particlesPerSecond = particlesPerSecond,
-                emittingTime = emittingTime,
-                maxParticles = maxParticles)
-        start()
-    }
-
-    fun doneEmitting(): Boolean {
-        return emitter.isDoneEmitting()
-    }
+    fun doneEmitting(): Boolean = emitter.isDoneEmitting()
 
     /**
      * Add the system to KonfettiView. KonfettiView will initiate the rendering


### PR DESCRIPTION
This function is can be removed, same result is possible with either:

`fun stream(particlesPerSecond: Int, emittingTime: Long)` 

or

`fun stream(particlesPerSecond: Int, maxParticles: Int)`

