### PR TITLE
Deprecate stream function single parameter

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -156,17 +156,6 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * Emit a certain amount of particles per second
      * calling this function will start the system rendering the confetti
      * [particlesPerSecond] amount of particles created per second
-     */
-    fun stream(particlesPerSecond: Int) {
-        emitter = StreamEmitter(location, velocity, sizes, shapes, colors, confettiConfig).emit(
-                particlesPerSecond = particlesPerSecond)
-        start()
-    }
-
-    /**
-     * Emit a certain amount of particles per second
-     * calling this function will start the system rendering the confetti
-     * [particlesPerSecond] amount of particles created per second
      * [emittingTime] max amount of time to emit in milliseconds
      */
     fun stream(particlesPerSecond: Int, emittingTime: Long) {


### PR DESCRIPTION
This function is useless until a stop function is build in the particle system. This way the particle system is able to support emitting an infinite amount of time with x amount of particles per second.