### PR TITLE
Fix issue #20 particles per second

### DIFF
--- a/konfetti/build.gradle
+++ b/konfetti/build.gradle
@@ -46,6 +46,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.8.9'
 }
 
 apply from: rootProject.file('gradle/install-v1.gradle')

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/KonfettiView.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/KonfettiView.kt
@@ -44,7 +44,7 @@ class KonfettiView : View {
         val deltaTime = timer.getDeltaTime()
         for (i in systems.size - 1 downTo 0) {
             val particleSystem = systems[i]
-            particleSystem.emitter.render(canvas, deltaTime)
+            particleSystem.renderSystem.render(canvas, deltaTime)
             if (particleSystem.doneEmitting()) {
                 systems.removeAt(i)
                 onParticleSystemUpdateListener?.onParticleSystemEnded(this, particleSystem, systems.size)

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -2,6 +2,7 @@ package nl.dionsegijn.konfetti
 
 import android.graphics.Color
 import nl.dionsegijn.konfetti.emitters.BurstEmitter
+import nl.dionsegijn.konfetti.emitters.Emitter
 import nl.dionsegijn.konfetti.emitters.RenderSystem
 import nl.dionsegijn.konfetti.emitters.StreamEmitter
 import nl.dionsegijn.konfetti.models.ConfettiConfig
@@ -148,33 +149,37 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * [amount] - the amount of particles created at burst
      */
     fun burst(amount: Int) {
-        val burstEmitter = BurstEmitter()
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, burstEmitter)
-        burstEmitter.build(amount)
-        start()
+        startRenderSystem(BurstEmitter().build(amount))
     }
 
     /**
-     * Emit a certain amount of particles per second
+     * Emit a certain amount of particles per second for the duration of specified time
      * calling this function will start the system rendering the confetti
      * [particlesPerSecond] amount of particles created per second
      * [emittingTime] max amount of time to emit in milliseconds
      */
     fun stream(particlesPerSecond: Int, emittingTime: Long) {
         val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, emittingTime = emittingTime)
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
-        start()
+        startRenderSystem(stream)
     }
 
     /**
-     * Emit a certain amount of particles per second
+     * Emit a certain amount of particles per second until [maxParticles] are created
      * calling this function will start the system rendering the confetti
      * [particlesPerSecond] amount of particles created per second
      * [maxParticles] max amount of particles to emit
      */
     fun stream(particlesPerSecond: Int, maxParticles: Int) {
         val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, maxParticles = maxParticles)
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
+        startRenderSystem(stream)
+    }
+
+    /**
+     * Initialize [RenderSystem] with specified [Emitter]
+     * By calling this function the system will start rendering confetti
+     */
+    private fun startRenderSystem(emitter: Emitter) {
+        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, emitter)
         start()
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -2,7 +2,7 @@ package nl.dionsegijn.konfetti
 
 import android.graphics.Color
 import nl.dionsegijn.konfetti.emitters.BurstEmitter
-import nl.dionsegijn.konfetti.emitters.Emitter
+import nl.dionsegijn.konfetti.emitters.RenderSystem
 import nl.dionsegijn.konfetti.emitters.StreamEmitter
 import nl.dionsegijn.konfetti.models.ConfettiConfig
 import nl.dionsegijn.konfetti.models.LocationModule
@@ -30,9 +30,9 @@ class ParticleSystem(val konfettiView: KonfettiView) {
 
     /**
      * Implementation of [BurstEmitter] or [StreamEmitter]
-     * Render function of the emitter is directly accessed from [KonfettiView]
+     * Render function of the renderSystem is directly accessed from [KonfettiView]
      */
-    internal lateinit var emitter: Emitter
+    internal lateinit var renderSystem: RenderSystem
 
     /**
      * Set position to emit particles from
@@ -148,7 +148,9 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * [amount] - the amount of particles created at burst
      */
     fun burst(amount: Int) {
-        emitter = BurstEmitter(location, velocity, sizes, shapes, colors, confettiConfig).burst(amount)
+        val burstEmitter = BurstEmitter()
+        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, burstEmitter)
+        burstEmitter.build(amount)
         start()
     }
 
@@ -159,9 +161,8 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * [emittingTime] max amount of time to emit in milliseconds
      */
     fun stream(particlesPerSecond: Int, emittingTime: Long) {
-        emitter = StreamEmitter(location, velocity, sizes, shapes, colors, confettiConfig).emit(
-                particlesPerSecond = particlesPerSecond,
-                emittingTime = emittingTime)
+        val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, emittingTime = emittingTime)
+        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
         start()
     }
 
@@ -172,13 +173,12 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * [maxParticles] max amount of particles to emit
      */
     fun stream(particlesPerSecond: Int, maxParticles: Int) {
-        emitter = StreamEmitter(location, velocity, sizes, shapes, colors, confettiConfig).emit(
-                particlesPerSecond = particlesPerSecond,
-                maxParticles = maxParticles)
+        val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, maxParticles = maxParticles)
+        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
         start()
     }
 
-    fun doneEmitting(): Boolean = emitter.isDoneEmitting()
+    fun doneEmitting(): Boolean = renderSystem.isDoneEmitting()
 
     /**
      * Add the system to KonfettiView. KonfettiView will initiate the rendering
@@ -188,7 +188,7 @@ class ParticleSystem(val konfettiView: KonfettiView) {
     }
 
     fun activeParticles(): Int {
-        return emitter.getActiveParticles()
+        return renderSystem.getActiveParticles()
     }
 
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -175,6 +175,17 @@ class ParticleSystem(val konfettiView: KonfettiView) {
     }
 
     /**
+     * Add your own custom Emitter. Create your own class and extend from [Emitter]
+     * See [BurstEmitter] and [StreamEmitter] as example classes on how to create your own emitter
+     * By calling this function the system wil start rendering the confetti according to your custom
+     * implementation
+     * @param [emitter] Custom implementation of the Emitter class
+     */
+    fun emitter(emitter: Emitter) {
+        startRenderSystem(emitter)
+    }
+
+    /**
      * Initialize [RenderSystem] with specified [Emitter]
      * By calling this function the system will start rendering confetti
      */

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
@@ -34,5 +34,5 @@ class BurstEmitter: Emitter() {
      * Tell the [RenderSystem] right away that the emitter is finished creating particles
      * since it's already done in [build]
      */
-    override fun doneCreatingParticles(): Boolean = true
+    override fun isFinished(): Boolean = true
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
@@ -3,9 +3,7 @@ package nl.dionsegijn.konfetti.emitters
 /**
  * Created by dionsegijn on 9/03/17.
  *
- * BurstEmitter creates a bunch of particles when [build] is called.
- * All the particles will be rendered at once by the [RenderSystem]
- * once it's active.
+ * BurstEmitter creates all confetti at once when [RenderSystem] is started
  */
 class BurstEmitter: Emitter() {
 
@@ -14,25 +12,33 @@ class BurstEmitter: Emitter() {
             field = if(value > 1000) 1000 else value
         }
 
+    private var isStarted = false
+
     /**
      * The amount of particles you want to create at once
      */
      fun build(amountOfParticles: Int): Emitter {
         this.amountOfParticles = amountOfParticles
-        for (i in 1..amountOfParticles) {
-            addConfettiFunc?.invoke()
-        }
+        isStarted = false
         return this
     }
 
     /**
-     * Skip implementation, all confetti is already created in the [build] function
+     * Create all confetti when the [RenderSystem] started, only do this once to render all
+     * particles at the same time
      */
-    override fun createConfetti(deltaTime: Float) {}
+    override fun createConfetti(deltaTime: Float) {
+        if(!isStarted) {
+            isStarted = true
+            for (i in 1..amountOfParticles) {
+                addConfettiFunc?.invoke()
+            }
+        }
+    }
 
     /**
      * Tell the [RenderSystem] right away that the emitter is finished creating particles
      * since it's already done in [build]
      */
-    override fun isFinished(): Boolean = true
+    override fun isFinished(): Boolean = isStarted
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
@@ -37,8 +37,8 @@ class BurstEmitter: Emitter() {
     }
 
     /**
-     * Tell the [RenderSystem] right away that the emitter is finished creating particles
-     * since it's already done in [build]
+     * When the particles are rendered in [createConfetti] the emitter is finished
+     * This is determined by [isStarted], it will only happen once
      */
     override fun isFinished(): Boolean = isStarted
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
@@ -1,35 +1,38 @@
 package nl.dionsegijn.konfetti.emitters
 
-import nl.dionsegijn.konfetti.models.ConfettiConfig
-import nl.dionsegijn.konfetti.models.LocationModule
-import nl.dionsegijn.konfetti.models.Shape
-import nl.dionsegijn.konfetti.models.Size
-import nl.dionsegijn.konfetti.modules.VelocityModule
-
 /**
- * Created by dionsegijn on 4/2/17.
+ * Created by dionsegijn on 9/03/17.
+ *
+ * BurstEmitter creates a bunch of particles when [build] is called.
+ * All the particles will be rendered at once by the [RenderSystem]
+ * once it's active.
  */
-open class BurstEmitter(location: LocationModule, velocity: VelocityModule, sizes: Array<Size>, shapes: Array<Shape>, colors: IntArray, config: ConfettiConfig) : Emitter(location, velocity, sizes, shapes, colors, config) {
+class BurstEmitter: Emitter() {
 
     private var amountOfParticles = 0
-        set(value) { if(value > 1000) field = 1000 else field = value }
+        set(value) {
+            field = if(value > 1000) 1000 else value
+        }
 
-    fun burst(amountOfParticles: Int): BurstEmitter {
+    /**
+     * The amount of particles you want to create at once
+     */
+     fun build(amountOfParticles: Int): Emitter {
         this.amountOfParticles = amountOfParticles
         for (i in 1..amountOfParticles) {
-            addConfetti()
+            addConfettiFunc?.invoke()
         }
         return this
     }
 
-    override fun createConfetti(deltaTime: Float) {
-        // Skip implementation since all confetti is already created
-    }
+    /**
+     * Skip implementation, all confetti is already created in the [build] function
+     */
+    override fun createConfetti(deltaTime: Float) {}
 
     /**
-     * Done emitting when all particles disappeared
+     * Tell the [RenderSystem] right away that the emitter is finished creating particles
+     * since it's already done in [build]
      */
-    override fun isDoneEmitting(): Boolean {
-        return particles.size == 0
-    }
+    override fun doneCreatingParticles(): Boolean = true
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/Emitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/Emitter.kt
@@ -1,56 +1,28 @@
 package nl.dionsegijn.konfetti.emitters
 
-import android.graphics.Canvas
-import nl.dionsegijn.konfetti.Confetti
-import nl.dionsegijn.konfetti.models.*
-import nl.dionsegijn.konfetti.models.Vector
-import nl.dionsegijn.konfetti.modules.VelocityModule
-import java.util.*
-
 /**
- * Implementation class for rendering confetti
- * Implementations like [BurstEmitter] and [StreamEmitter] define at
- * what rate the confetti is created while Emitter is creating the confetti
- * and passing through the canvas to let the confetti render itself
+ * Created by dionsegijn on 9/03/17.
+ *
+ * An abstract class for creating a custom emitter
+ * The only goal of the emitter is to tell when and how many particles to create
  */
-abstract class Emitter(val location: LocationModule,
-                       val velocity: VelocityModule,
-                       val sizes: Array<Size>,
-                       val shapes: Array<Shape>,
-                       val colors: IntArray,
-                       val config: ConfettiConfig) {
+abstract class Emitter {
 
-    private val random = Random()
-    private var gravity = Vector(0f, 0.01f)
-    internal val particles: MutableList<Confetti> = mutableListOf()
+    /**
+     * Call this function to tell the RenderSystem to render a particle
+     */
+    var addConfettiFunc: (() -> Unit)? = null
 
+    /**
+     * This function is called on each update when the [RenderSystem] is active
+     * Keep this function as light as possible otherwise you'll slow down the render system
+     */
     abstract fun createConfetti(deltaTime: Float)
-    abstract fun isDoneEmitting(): Boolean
 
-    open fun addConfetti() {
-        particles.add(Confetti(
-                location = Vector(location.x, location.y),
-                size = sizes[random.nextInt(sizes.size)],
-                shape = shapes[random.nextInt(shapes.size)],
-                color = colors[random.nextInt(colors.size)],
-                lifespan = config.timeToLive,
-                fadeOut = config.fadeOut,
-                velocity = this.velocity.getVelocity())
-        )
-    }
-
-    fun render(canvas: Canvas, deltaTime: Float) {
-        createConfetti(deltaTime)
-
-        for(i in particles.size-1 downTo 0) {
-            val particle = particles[i]
-            particle.applyForce(gravity)
-            particle.render(canvas, deltaTime)
-            if(particle.isDead()) particles.removeAt(i)
-        }
-    }
-
-    fun getActiveParticles(): Int {
-        return particles.size
-    }
+    /**
+     * Tell the renderer when the renderSystem is done creating particles
+     * @return true if the renderSystem is not longer creating any particles
+     *         false if the renderSystem is still busy
+     */
+    abstract fun doneCreatingParticles(): Boolean
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/Emitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/Emitter.kt
@@ -20,9 +20,9 @@ abstract class Emitter {
     abstract fun createConfetti(deltaTime: Float)
 
     /**
-     * Tell the renderer when the renderSystem is done creating particles
+     * Tell the [RenderSystem] when the emitter is done creating particles
      * @return true if the renderSystem is not longer creating any particles
      *         false if the renderSystem is still busy
      */
-    abstract fun doneCreatingParticles(): Boolean
+    abstract fun isFinished(): Boolean
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -55,5 +55,5 @@ class RenderSystem(
 
     fun getActiveParticles(): Int = particles.size
 
-    fun isDoneEmitting(): Boolean = emitter.doneCreatingParticles() && particles.size == 0
+    fun isDoneEmitting(): Boolean = emitter.isFinished() && particles.size == 0
 }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -1,0 +1,59 @@
+package nl.dionsegijn.konfetti.emitters
+
+import android.graphics.Canvas
+import nl.dionsegijn.konfetti.Confetti
+import nl.dionsegijn.konfetti.models.*
+import nl.dionsegijn.konfetti.models.Vector
+import nl.dionsegijn.konfetti.modules.VelocityModule
+import java.util.*
+
+/**
+ * Implementation class for rendering confetti
+ * Implementations like [BurstEmitter] and [StreamEmitter] define at
+ * what rate the confetti is created while RenderSystem is creating the confetti
+ * and passing through the canvas to let the confetti render itself
+ */
+class RenderSystem(
+        private val location: LocationModule,
+        private val velocity: VelocityModule,
+        private val sizes: Array<Size>,
+        private val shapes: Array<Shape>,
+        private val colors: IntArray,
+        private val config: ConfettiConfig,
+        private val emitter: Emitter) {
+
+    private val random = Random()
+    private var gravity = Vector(0f, 0.01f)
+    private val particles: MutableList<Confetti> = mutableListOf()
+
+    init {
+        emitter.addConfettiFunc = this::addConfetti
+    }
+
+    private fun addConfetti() {
+        particles.add(Confetti(
+                location = Vector(location.x, location.y),
+                size = sizes[random.nextInt(sizes.size)],
+                shape = shapes[random.nextInt(shapes.size)],
+                color = colors[random.nextInt(colors.size)],
+                lifespan = config.timeToLive,
+                fadeOut = config.fadeOut,
+                velocity = this.velocity.getVelocity())
+        )
+    }
+
+    fun render(canvas: Canvas, deltaTime: Float) {
+        emitter.createConfetti(deltaTime)
+
+        for(i in particles.size-1 downTo 0) {
+            val particle = particles[i]
+            particle.applyForce(gravity)
+            particle.render(canvas, deltaTime)
+            if(particle.isDead()) particles.removeAt(i)
+        }
+    }
+
+    fun getActiveParticles(): Int = particles.size
+
+    fun isDoneEmitting(): Boolean = emitter.doneCreatingParticles() && particles.size == 0
+}

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
@@ -5,7 +5,6 @@ import nl.dionsegijn.konfetti.models.LocationModule
 import nl.dionsegijn.konfetti.models.Shape
 import nl.dionsegijn.konfetti.models.Size
 import nl.dionsegijn.konfetti.modules.VelocityModule
-import java.util.concurrent.TimeUnit
 
 /**
  * Created by dionsegijn on 4/2/17.
@@ -17,47 +16,57 @@ class StreamEmitter(location: LocationModule, velocity: VelocityModule, sizes: A
     /** Keeping count of how many particles are created */
     private var particlesCreated = 0
     /** Max time in milliseconds allowed to emit */
-    internal var emittingTime: Long = 0
+    private var emittingTime: Long = 0
     /** Elapsed time in milliseconds */
-    internal var elapsedTime: Float = 0f
+    private var elapsedTime: Float = 0f
     /** Milliseconds per particle creation */
-    var amountPerMs: Long = 0L
+    private var amountPerMs: Float = 0f
+    /** Elapsed time in milliseconds */
+    private var createParticleMs: Float = 0f
 
     fun emit(particlesPerSecond: Int, emittingTime: Long = 0L, maxParticles: Int = -1): StreamEmitter {
         this.maxParticles = maxParticles
         this.emittingTime = emittingTime
-        amountPerMs = TimeUnit.NANOSECONDS.toMillis(1000L / particlesPerSecond)
+        amountPerMs = 1f / particlesPerSecond
+        addConfetti()
         return this
     }
 
     /**
      * If timer isn't started yet, set initial start time
-     * Create the first confetti immediately and update the last emit time
+     * Create the first confetti immediately and update the last emitting time
      */
     override fun createConfetti(deltaTime: Float) {
 
-        // if maxParticles is set and particlesCreated not within
-        // range of maxParticles stop emitting
+        // If maxParticles is set and amount of particles created is not within the range of
+        // maxParticles stop emitting
         if(maxParticles in 1..(particlesCreated - 1)) {
             return
         }
 
         // Check if particle should be created
-        if (deltaTime >= amountPerMs && elapsedTime < emittingTime) {
-            this.addConfetti()
+        if(createParticleMs > amountPerMs && !isTimeElapsed()) {
+            // Calculate how many particle  to create in the elapsed time
+            val amount: Int = (createParticleMs / amountPerMs).toInt()
+            (1..amount).forEach { this.addConfetti() }
+            // Reset timer and add left over time for the next cycle
+            createParticleMs %= amountPerMs
         }
+        createParticleMs += deltaTime
 
         elapsedTime += deltaTime * 1000
     }
+
+    private fun isTimeElapsed(): Boolean = if(emittingTime == 0L) false else elapsedTime > emittingTime
 
     /**
      * When time is up and all particles disappeared
      */
     override fun isDoneEmitting(): Boolean {
-        if(emittingTime > 0L) {
-            return elapsedTime >= emittingTime && particles.size == 0
+        return if(emittingTime > 0L) {
+            elapsedTime >= emittingTime && particles.size == 0
         } else {
-            return particles.size == 0
+            particles.size == 0
         }
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
@@ -15,13 +15,13 @@ class StreamEmitter(location: LocationModule, velocity: VelocityModule, sizes: A
     private var maxParticles = -1
     /** Keeping count of how many particles are created */
     private var particlesCreated = 0
-    /** Max time in milliseconds allowed to emit */
+    /** Max time allowed to emit in milliseconds */
     private var emittingTime: Long = 0
     /** Elapsed time in milliseconds */
     private var elapsedTime: Float = 0f
-    /** Milliseconds per particle creation */
+    /** Amount of time needed for each particle creation in milliseconds */
     private var amountPerMs: Float = 0f
-    /** Elapsed time in milliseconds */
+    /** Amount of time elapsed since last particle creation in milliseconds */
     private var createParticleMs: Float = 0f
 
     fun emit(particlesPerSecond: Int, emittingTime: Long = 0L, maxParticles: Int = -1): StreamEmitter {

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/StreamEmitter.kt
@@ -79,7 +79,7 @@ class StreamEmitter : Emitter() {
      * If the [emittingTime] is not set tell the [RenderSystem] that the emitter is finished
      * creating particles when [particlesCreated] exceeded [maxParticles]
      */
-    override fun doneCreatingParticles(): Boolean {
+    override fun isFinished(): Boolean {
         return if (emittingTime > 0L) {
             elapsedTime >= emittingTime
         } else {

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/TimerModule.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/TimerModule.kt
@@ -7,7 +7,7 @@ class TimerModule {
     /**
      * Current time should be used when calculating
      * the elapsed time, it will be updated once when
-     * rendering the particles of the emitter
+     * rendering the particles in the renderSystem
      * @property currentTime in nanoseconds
      */
     var currentTime: Long = 0L

--- a/konfetti/src/test/java/nl/dionsegijn/konfetti/Emitter/StreamEmitterTests.kt
+++ b/konfetti/src/test/java/nl/dionsegijn/konfetti/Emitter/StreamEmitterTests.kt
@@ -1,0 +1,85 @@
+package nl.dionsegijn.konfetti.Emitter
+
+import nl.dionsegijn.konfetti.emitters.StreamEmitter
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+/**
+ * Created by dionsegijn on 4/2/17.
+ */
+class StreamEmitterTests {
+
+    private lateinit var streamEmitter: StreamEmitter
+    private lateinit var mockInvokeMethodClass: MockInvokeMethodClass
+
+    @Before
+    fun before() {
+        mockInvokeMethodClass = Mockito.mock(MockInvokeMethodClass::class.java)
+        streamEmitter = StreamEmitter()
+        streamEmitter.addConfettiFunc = mockInvokeMethodClass::invokeMethod
+    }
+
+    @Test
+    fun test_Stream_OneParticlePerSecond() {
+        streamEmitter.build(
+                particlesPerSecond = 1,
+                emittingTime = 3000
+        )
+
+        // Test how many particles are created in three seconds
+        // Expected: 3
+        val threeSeconds = 3f
+        streamEmitter.createConfetti(threeSeconds)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(3)).invokeMethod()
+
+        // Test how many particles are created in one more second
+        // Expected: 3
+        // Still 3 because emmitingTime = 3000ms so the streamer is done emitting
+        val oneSecond = 1f
+        streamEmitter.createConfetti(oneSecond)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(3)).invokeMethod()
+    }
+
+    @Test
+    fun test_Stream_HundredParticlesPerSecond() {
+        streamEmitter.build(
+                particlesPerSecond = 100,
+                emittingTime = 3000
+        )
+
+        // Test how many particles are created in 100ms
+        // Expected: 10
+        streamEmitter.createConfetti(0.1f)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(10)).invokeMethod()
+
+        // Test how many particles are created in one second
+        // Expected: 110 (including 10 from the previous test)
+        val oneSecond = 1f
+        streamEmitter.createConfetti(oneSecond)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(110)).invokeMethod()
+    }
+
+    @Test
+    fun test_Stream_tenParticlesPerSecond_maxTwelveParticles() {
+        streamEmitter.build(
+                particlesPerSecond = 10,
+                maxParticles = 12
+        )
+
+        // Test how many particles are created in one second
+        // Expected: 10
+        streamEmitter.createConfetti(1f)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(10)).invokeMethod()
+
+        // Another second means 2 more particles instead of 10 because maximum is reached
+        streamEmitter.createConfetti(1f)
+        Mockito.verify(mockInvokeMethodClass, Mockito.times(12)).invokeMethod()
+    }
+}
+
+class MockInvokeMethodClass {
+    fun invokeMethod() {
+
+    }
+}

--- a/konfetti/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/konfetti/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### What does this PR do?

This pull requests fixes issue #20 reported by @ANPez. I wrote some [tests](https://github.com/DanielMartinus/Konfetti/compare/fix/issue_20_particles_per_second?expand=1#diff-e1c4d89d24638cde5a9e1b3a4dff3dfcR11) for the StreamerEmitter to guarantee this bug won't happen again in the future. In order to make better tests I had to refactor how the `RenderSystem` (before called `Emitter`) was communicating with the other emitter implementations.

### Refactor Emitter to RenderSystem

As stated in the description I had to refactor RenderSystem and isolate the BurstEmitter and StreamEmitter logic from the base Emitter to make the code testable. 

The new Emitter implementations do not know about the RenderSystem anymore. This means they do not contain any Android SDK related stuff anymore and only implement the logic to tell the renderer when and how many particles to create. This way every Emitter is very testable through unit tests without any complex mocking. 

Though the Emitter base class holds a reference of an higher-order function to tell the RenderSystem when to create a new particle.
