### PR TITLE
Fix burst emitter rendering

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -2,6 +2,7 @@ package nl.dionsegijn.konfetti
 
 import android.graphics.Color
 import nl.dionsegijn.konfetti.emitters.BurstEmitter
+import nl.dionsegijn.konfetti.emitters.Emitter
 import nl.dionsegijn.konfetti.emitters.RenderSystem
 import nl.dionsegijn.konfetti.emitters.StreamEmitter
 import nl.dionsegijn.konfetti.models.ConfettiConfig
@@ -148,33 +149,37 @@ class ParticleSystem(val konfettiView: KonfettiView) {
      * [amount] - the amount of particles created at burst
      */
     fun burst(amount: Int) {
-        val burstEmitter = BurstEmitter()
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, burstEmitter)
-        burstEmitter.build(amount)
-        start()
+        startRenderSystem(BurstEmitter().build(amount))
     }
 
     /**
-     * Emit a certain amount of particles per second
+     * Emit a certain amount of particles per second for the duration of specified time
      * calling this function will start the system rendering the confetti
      * [particlesPerSecond] amount of particles created per second
      * [emittingTime] max amount of time to emit in milliseconds
      */
     fun stream(particlesPerSecond: Int, emittingTime: Long) {
         val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, emittingTime = emittingTime)
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
-        start()
+        startRenderSystem(stream)
     }
 
     /**
-     * Emit a certain amount of particles per second
+     * Emit a certain amount of particles per second until [maxParticles] are created
      * calling this function will start the system rendering the confetti
      * [particlesPerSecond] amount of particles created per second
      * [maxParticles] max amount of particles to emit
      */
     fun stream(particlesPerSecond: Int, maxParticles: Int) {
         val stream = StreamEmitter().build(particlesPerSecond = particlesPerSecond, maxParticles = maxParticles)
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, stream)
+        startRenderSystem(stream)
+    }
+
+    /**
+     * Initialize [RenderSystem] with specified [Emitter]
+     * By calling this function the system will start rendering confetti
+     */
+    private fun startRenderSystem(emitter: Emitter) {
+        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, emitter)
         start()
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/BurstEmitter.kt
@@ -3,9 +3,7 @@ package nl.dionsegijn.konfetti.emitters
 /**
  * Created by dionsegijn on 9/03/17.
  *
- * BurstEmitter creates a bunch of particles when [build] is called.
- * All the particles will be rendered at once by the [RenderSystem]
- * once it's active.
+ * BurstEmitter creates all confetti at once when [RenderSystem] is started
  */
 class BurstEmitter: Emitter() {
 
@@ -14,25 +12,33 @@ class BurstEmitter: Emitter() {
             field = if(value > 1000) 1000 else value
         }
 
+    private var isStarted = false
+
     /**
      * The amount of particles you want to create at once
      */
      fun build(amountOfParticles: Int): Emitter {
         this.amountOfParticles = amountOfParticles
-        for (i in 1..amountOfParticles) {
-            addConfettiFunc?.invoke()
-        }
+        isStarted = false
         return this
     }
 
     /**
-     * Skip implementation, all confetti is already created in the [build] function
+     * Create all confetti when the [RenderSystem] started, only do this once to render all
+     * particles at the same time
      */
-    override fun createConfetti(deltaTime: Float) {}
+    override fun createConfetti(deltaTime: Float) {
+        if(!isStarted) {
+            isStarted = true
+            for (i in 1..amountOfParticles) {
+                addConfettiFunc?.invoke()
+            }
+        }
+    }
 
     /**
      * Tell the [RenderSystem] right away that the emitter is finished creating particles
      * since it's already done in [build]
      */
-    override fun isFinished(): Boolean = true
+    override fun isFinished(): Boolean = isStarted
 }


### PR DESCRIPTION
Fix the way burst emitter starts rendering. Cleaned up the code a bit so everything is done in the Emitter instead of the small work around in `ParticleSystem`