### PR TITLE
Improvements on Size

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -7,7 +7,6 @@ import android.graphics.RectF
 import nl.dionsegijn.konfetti.models.Shape
 import nl.dionsegijn.konfetti.models.Size
 import nl.dionsegijn.konfetti.models.Vector
-import nl.dionsegijn.konfetti.models.sizeInPx
 import java.util.*
 
 class Confetti(var location: Vector,

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
@@ -4,10 +4,10 @@ import android.content.res.Resources
 
 /**
  * Created by dionsegijn on 3/26/17.
- * [size] the size of the confetti in dip
+ * [sizeInDp] the size of the confetti in dip
  * [mass] each size can have its own mass for slightly different behavior
  */
-data class Size(val size: Int, val mass: Float = 5f)
+data class Size(val sizeInDp: Int, val mass: Float = 5f)
 
 val Size.sizeDp: Int
-    get() = (this.size * Resources.getSystem().displayMetrics.density).toInt()
+    get() = (this.sizeInDp * Resources.getSystem().displayMetrics.density).toInt()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
@@ -5,9 +5,16 @@ import android.content.res.Resources
 /**
  * Created by dionsegijn on 3/26/17.
  * [sizeInDp] the size of the confetti in dip
- * [mass] each size can have its own mass for slightly different behavior
+ * [mass] each size can have its own mass for slightly different behavior. For example, the closer
+ * the mass is to zero the easier it will accelerate.
  */
-data class Size(val sizeInDp: Int, val mass: Float = 5f)
+data class Size(val sizeInDp: Int, val mass: Float = 5f) {
 
-val Size.sizeInPx: Float
-    get() = (this.sizeInDp * Resources.getSystem().displayMetrics.density)
+    internal val sizeInPx: Float
+        get() = sizeInDp * Resources.getSystem().displayMetrics.density
+
+    init {
+        require(mass != 0F) { "mass=$mass must be != 0" }
+    }
+
+}

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Size.kt
@@ -9,5 +9,5 @@ import android.content.res.Resources
  */
 data class Size(val sizeInDp: Int, val mass: Float = 5f)
 
-val Size.sizeDp: Int
-    get() = (this.sizeInDp * Resources.getSystem().displayMetrics.density).toInt()
+val Size.sizeInPx: Float
+    get() = (this.sizeInDp * Resources.getSystem().displayMetrics.density)


### PR DESCRIPTION
This Pull request is linked to #34 created by @PaulWoitaschek addressing:

- Naming issues. property `size` becomes `sizeInDp`, `sizeDp` is renamed to `sizeInPx`. 
- Do not cast `sizeInPx` as an Int but as a Float
- Validate mass to prevent it being 0