### PR TITLE
Adds method to set a List<Int> as colors

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -70,7 +70,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * One of the colors will be randomly picked when confetti is generated
      * Default color is Color.RED
      */
-    fun addColors(vararg colors: List<Int>): ParticleSystem {
+    fun addColors(var colors: List<Int>): ParticleSystem {
         this.colors = colors.toIntArray()
         return this
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -65,6 +65,15 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
         this.colors = colors
         return this
     }
+    
+    /**
+     * One of the colors will be randomly picked when confetti is generated
+     * Default color is Color.RED
+     */
+    fun addColors(vararg colors: List<Int>): ParticleSystem {
+        this.colors = colors.toIntArray()
+        return this
+    }
 
     /**
      * Add one or more different sizes by defining a [Size] in dip and optionally its mass

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -60,6 +60,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     /**
      * One of the colors will be randomly picked when confetti is generated
      * Default color is Color.RED
+     * @param colors [IntArray] with color integers
      */
     fun addColors(vararg colors: Int): ParticleSystem {
         this.colors = colors
@@ -69,6 +70,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     /**
      * One of the colors will be randomly picked when confetti is generated
      * Default color is Color.RED
+     * @param colors a list with colors integers
      */
     fun addColors(colors: List<Int>): ParticleSystem {
         this.colors = colors.toIntArray()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -70,7 +70,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * One of the colors will be randomly picked when confetti is generated
      * Default color is Color.RED
      */
-    fun addColors(var colors: List<Int>): ParticleSystem {
+    fun addColors(colors: List<Int>): ParticleSystem {
         this.colors = colors.toIntArray()
         return this
     }


### PR DESCRIPTION
I just wrote this real quick at Github.com, so I might have missed something, but it seemed simple enough.

This is useful in case you want to have a list of colors that you already have populated before building the confetti. In my case I get a list of integers from a backend which I want to use. 