### PR TITLE
Change import sample from compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Just add the following dependency in your app's build.gradle
 
 ```groovy
 dependencies {
-      compile 'nl.dionsegijn:konfetti:1.1.2'
+      implementation 'nl.dionsegijn:konfetti:1.1.2'
 }
 ```
  [ ![Download](https://api.bintray.com/packages/danielmartinus/maven/Konfetti/images/download.svg) ](https://bintray.com/danielmartinus/maven/Konfetti/_latestVersion)


### PR DESCRIPTION
This is the new recommended format for import statements. Using `compile` is deprecated.

See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation for more information.