### PR TITLE
Control acceleration

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -18,7 +18,9 @@ class Confetti(
     val fadeOut: Boolean = true,
     private var acceleration: Vector = Vector(0f, 0f),
     var velocity: Vector = Vector(),
-    val rotate: Boolean = true
+    val rotate: Boolean = true,
+    val accelerate: Boolean = true,
+    val maxAcceleration: Float = -1f
 ) {
 
     private val mass = size.mass
@@ -59,7 +61,9 @@ class Confetti(
     }
 
     private fun update(deltaTime: Float) {
-        velocity.add(acceleration)
+        if (accelerate && (acceleration.y < maxAcceleration || maxAcceleration == -1f)) {
+            velocity.add(acceleration)
+        }
 
         val v = velocity.copy()
         v.mult(deltaTime * speedF)

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -156,7 +156,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     /**
      * Enable or disable the 3D rotation of the particle
      */
-    fun setAccelerate(enabled: Boolean): ParticleSystem {
+    fun setAccelerationEnabled(enabled: Boolean): ParticleSystem {
         confettiConfig.accelerate = enabled
         return this
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -137,10 +137,27 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     }
 
     /**
+     * Set a maximum acceleration that can be added to the velocity of the particle.
+     * This way the particle can't accelerate faster than the max speed + max acceleration
+     */
+    fun setMaxAcceleration(maxAcceleration: Float): ParticleSystem {
+        velocity.maxAcceleration = maxAcceleration / 10
+        return this
+    }
+
+    /**
      * Enable or disable the 3D rotation of the particle
      */
     fun setRotationEnabled(enabled: Boolean): ParticleSystem {
         confettiConfig.rotate = enabled
+        return this
+    }
+
+    /**
+     * Enable or disable the 3D rotation of the particle
+     */
+    fun setAccelerate(enabled: Boolean): ParticleSystem {
+        confettiConfig.accelerate = enabled
         return this
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -48,7 +48,9 @@ class RenderSystem(
                 lifespan = config.timeToLive,
                 fadeOut = config.fadeOut,
                 velocity = this.velocity.getVelocity(),
-                rotate = config.rotate)
+                rotate = config.rotate,
+                maxAcceleration = velocity.maxAcceleration,
+                accelerate = config.accelerate)
         )
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
@@ -7,5 +7,6 @@ package nl.dionsegijn.konfetti.models
 data class ConfettiConfig(
     var fadeOut: Boolean = false,
     var timeToLive: Long = 2000L,
-    var rotate: Boolean = true
+    var rotate: Boolean = true,
+    var accelerate: Boolean = true
 )

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/VelocityModule.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/VelocityModule.kt
@@ -39,6 +39,8 @@ class VelocityModule(private val random: Random) {
             field = if (value!! < 0) 0f else value
         }
 
+    var maxAcceleration: Float = -1f
+
     /**
      * If both minSpeed and maxSpeed are set a random speed between those values will be returned
      * Otherwise only the minimum speed will be returned


### PR DESCRIPTION
# Acceleration

This PR adds two options regarding acceleration.
- Turn of acceleration of the particles (per tick)
- Set a MaxAcceleration that a particle can reach

Fixes #48 

## Turn off acceleration

Only turning off the acceleration will result the particles having the same velocity they begin with. This can be done with:
```Kotlin
konfettiView.build()
    ...
    .setAccelerationEnabled(false)
```

## Set max acceleration

If you don't want the particles to keep the speed they begin with but have a slight change in velocity for a more natural feeling, you can use setMaxAccelaration.

```Kotlin
konfettiView.build()
    ...
    .setMaxAcceleration(1.5f)
```

A maxAcceleration between 1.0 - 3.0 is visible in the lifetime of a particle

## Demo

Using `setMaxAcceleration` you could achieve an effect like this:

![86518934-c4a65280-be35-11ea-9393-bf9a88c7bd3f](https://user-images.githubusercontent.com/1636897/86529930-b9463c00-beb4-11ea-8986-1e1e6a72b564.gif)

The particle accelerate in the beginning and then keep a constant velocity