### PR TITLE
Add control for rotation speed multiplier

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -21,7 +21,7 @@ class Confetti(
     val rotate: Boolean = true,
     val accelerate: Boolean = true,
     val maxAcceleration: Float = -1f,
-    rotationSpeedMultiplier: Float = 1f
+    val rotationSpeedMultiplier: Float = 1f
 ) {
 
     private val mass = size.mass

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -20,7 +20,8 @@ class Confetti(
     var velocity: Vector = Vector(),
     val rotate: Boolean = true,
     val accelerate: Boolean = true,
-    val maxAcceleration: Float = -1f
+    val maxAcceleration: Float = -1f,
+    rotationSpeedMultiplier: Float = 1f
 ) {
 
     private val mass = size.mass
@@ -40,7 +41,7 @@ class Confetti(
         val minRotationSpeed = 0.29f * Resources.getSystem().displayMetrics.density
         val maxRotationSpeed = minRotationSpeed * 3
         if (rotate) {
-            rotationSpeed = maxRotationSpeed * Random.nextFloat() + minRotationSpeed
+            rotationSpeed = (maxRotationSpeed * Random.nextFloat() + minRotationSpeed) * rotationSpeedMultiplier
         }
         paint.color = color
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -153,8 +153,21 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
         return this
     }
 
+    /**
+     * Set a multiplier for the rotation speed of the particles if rotation is enabled
+     */
     fun setRotationSpeedMultiplier(multiplier: Float): ParticleSystem {
-        confettiConfig.rotationSpeedMultiplier = multiplier
+        require(multiplier >= 0f) { "multiplier ($multiplier) must be greater or equal to 0"}
+        velocity.baseRotationMultiplier = multiplier
+        return this
+    }
+
+    /**
+     * Set a rotation speed variance in percent on the multiplier
+     */
+    fun setRotationSpeedVariance(variance: Float): ParticleSystem {
+        require(variance in 0f..1f) { "variance ($variance) must be in the range 0..1"}
+        velocity.rotationVariance = variance
         return this
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -157,7 +157,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * Set a multiplier for the rotation speed of the particles if rotation is enabled
      */
     fun setRotationSpeedMultiplier(multiplier: Float): ParticleSystem {
-        require(multiplier >= 0f) { "multiplier ($multiplier) must be greater or equal to 0"}
+        require(multiplier >= 0f) { "multiplier ($multiplier) must be greater or equal to 0" }
         velocity.baseRotationMultiplier = multiplier
         return this
     }
@@ -166,7 +166,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * Set a rotation speed variance in percent on the multiplier
      */
     fun setRotationSpeedVariance(variance: Float): ParticleSystem {
-        require(variance in 0f..1f) { "variance ($variance) must be in the range 0..1"}
+        require(variance in 0f..1f) { "variance ($variance) must be in the range 0..1" }
         velocity.rotationVariance = variance
         return this
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -153,8 +153,13 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
         return this
     }
 
+    fun setRotationSpeedMultiplier(multiplier: Float): ParticleSystem {
+        confettiConfig.rotationSpeedMultiplier = multiplier
+        return this
+    }
+
     /**
-     * Enable or disable the 3D rotation of the particle
+     * Enable or disable the acceleration of the particle
      */
     fun setAccelerationEnabled(enabled: Boolean): ParticleSystem {
         confettiConfig.accelerate = enabled

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -51,7 +51,7 @@ class RenderSystem(
                 rotate = config.rotate,
                 maxAcceleration = velocity.maxAcceleration,
                 accelerate = config.accelerate,
-                rotationSpeedMultiplier = config.rotationSpeedMultiplier)
+                rotationSpeedMultiplier = velocity.getRotationSpeedMultiplier())
         )
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -50,7 +50,8 @@ class RenderSystem(
                 velocity = this.velocity.getVelocity(),
                 rotate = config.rotate,
                 maxAcceleration = velocity.maxAcceleration,
-                accelerate = config.accelerate)
+                accelerate = config.accelerate,
+                rotationSpeedMultiplier = config.rotationSpeedMultiplier)
         )
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
@@ -8,6 +8,5 @@ data class ConfettiConfig(
     var fadeOut: Boolean = false,
     var timeToLive: Long = 2000L,
     var rotate: Boolean = true,
-    var accelerate: Boolean = true,
-    var rotationSpeedMultiplier: Float = 1f
+    var accelerate: Boolean = true
 )

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
@@ -8,5 +8,6 @@ data class ConfettiConfig(
     var fadeOut: Boolean = false,
     var timeToLive: Long = 2000L,
     var rotate: Boolean = true,
-    var accelerate: Boolean = true
+    var accelerate: Boolean = true,
+    var rotationSpeedMultiplier: Float = 1f
 )

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/VelocityModule.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/modules/VelocityModule.kt
@@ -13,6 +13,7 @@ class VelocityModule(private val random: Random) {
      * Minimum angle as Radian
      */
     var minAngle: Double = 0.0
+
     /**
      * Maximum angle as Radian
      * Once set it will be used to randomize between [minAngle] and maxAngle when velocity
@@ -28,6 +29,7 @@ class VelocityModule(private val random: Random) {
         set(value) {
             field = if (value < 0) 0f else value
         }
+
     /**
      * Maximum speed (magnitude)
      * Once set it will be used to randomize between [minSpeed] and maxSpeed when velocity
@@ -40,6 +42,16 @@ class VelocityModule(private val random: Random) {
         }
 
     var maxAcceleration: Float = -1f
+
+    /**
+     * Minimum rotation speed multiplier
+     */
+    var baseRotationMultiplier: Float = 1f
+
+    /**
+     * Variance in rotation speed from the base multiplier given in percent
+     */
+    var rotationVariance: Float = 0.2f
 
     /**
      * If both minSpeed and maxSpeed are set a random speed between those values will be returned
@@ -77,5 +89,14 @@ class VelocityModule(private val random: Random) {
         val vx = speed * Math.cos(radian).toFloat()
         val vy = speed * Math.sin(radian).toFloat()
         return Vector(vx, vy)
+    }
+
+    /**
+     * Calculate a rotation speed multiplier based on the base and variance
+     * return float multiplier
+     */
+    fun getRotationSpeedMultiplier(): Float {
+        val randomValue = random.nextFloat() * 2f - 1f
+        return baseRotationMultiplier + (baseRotationMultiplier * rotationVariance * randomValue)
     }
 }


### PR DESCRIPTION
Addresses issue #185 by giving users an extra multiplier on the rotation speed of the Confetti using the `setRotationSpeedMultiplier` on the `ParticleSystem`. Tested and it works.