### PR TITLE
Fix mutable state DrawableShape

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -1,6 +1,7 @@
 package nl.dionsegijn.konfetti.emitters
 
 import android.graphics.Canvas
+import android.graphics.drawable.ShapeDrawable
 import nl.dionsegijn.konfetti.Confetti
 import nl.dionsegijn.konfetti.models.ConfettiConfig
 import nl.dionsegijn.konfetti.models.Shape
@@ -43,7 +44,7 @@ class RenderSystem(
         particles.add(Confetti(
                 location = Vector(location.x, location.y),
                 size = sizes[random.nextInt(sizes.size)],
-                shape = shapes[random.nextInt(shapes.size)],
+                shape = getRandomShape(),
                 color = colors[random.nextInt(colors.size)],
                 lifespan = config.timeToLive,
                 fadeOut = config.fadeOut,
@@ -53,6 +54,20 @@ class RenderSystem(
                 accelerate = config.accelerate,
                 rotationSpeedMultiplier = velocity.getRotationSpeedMultiplier())
         )
+    }
+
+    /**
+     * When the shape is a DrawableShape, mutate the drawable so that all drawables
+     * have different values when drawn on the canvas.
+     */
+    private fun getRandomShape(): Shape {
+        return when (val shape = shapes[random.nextInt(shapes.size)]) {
+            is Shape.DrawableShape -> {
+                val mutatedState = shape.drawable.constantState?.newDrawable()?.mutate() ?: shape.drawable
+                shape.copy(drawable = mutatedState)
+            }
+            else -> shape
+        }
     }
 
     fun render(canvas: Canvas, deltaTime: Float) {

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -1,7 +1,6 @@
 package nl.dionsegijn.konfetti.emitters
 
 import android.graphics.Canvas
-import android.graphics.drawable.ShapeDrawable
 import nl.dionsegijn.konfetti.Confetti
 import nl.dionsegijn.konfetti.models.ConfettiConfig
 import nl.dionsegijn.konfetti.models.Shape

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Shape.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Shape.kt
@@ -63,12 +63,11 @@ interface Shape {
         }
     }
 
-    class DrawableShape(
-        drawable: Drawable,
+    data class DrawableShape(
+        val drawable: Drawable,
         /** Set to `false` to opt out of tinting the drawable, keeping its original colors. */
         private val tint: Boolean = true
     ) : Shape {
-        private val drawable = drawable.mutate()
         private val heightRatio =
             if (drawable.intrinsicHeight == -1 && drawable.intrinsicWidth == -1) {
                 // If the drawable has no intrinsic size, fill the available space.


### PR DESCRIPTION
Drawable shapes were mutated inside the `DrawableShape` object. However this object is reused across all the Confetti objects and this resulted in the same state being shared over all the confetti particles. This fix mutates the drawable state when a Confetti Particle is created. So for each DrawableShape a new Drawable instance is copied that holds a reference to its own alpha and color values.

| Before | After |
|-|-|
| <img src="https://user-images.githubusercontent.com/1636897/92992561-2fd26c00-f4ec-11ea-9f82-141ea53265ba.gif" width=300/> | <img src="https://user-images.githubusercontent.com/1636897/92992595-6c05cc80-f4ec-11ea-948b-e7f9dc6bc4ca.gif" width=300/> |




