### PR TITLE
optimize rendering loop by avoiding creation of temporary Vector objects

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -79,8 +79,8 @@ class RenderSystem(
             val particle = particles[i]
             particle.applyForce(gravity)
             particle.render(canvas, deltaTime)
-            if (particle.isDead()) particles.removeAt(i)
         }
+        particles.removeAll { it.isDead() }
     }
 
     fun getActiveParticles(): Int = particles.size

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Vector.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/Vector.kt
@@ -9,6 +9,11 @@ data class Vector(var x: Float = 0f, var y: Float = 0f) {
         y += v.y
     }
 
+    fun addScaled(v: Vector, s: Float) {
+        x += v.x * s
+        y += v.y * s
+    }
+
     fun mult(n: Float) {
         x *= n
         y *= n


### PR DESCRIPTION
I noticed with the Profiler in AndroidStudio that it creates a lot of Vector objects during rendering and then frequently runs the garbage collector. This change optimizes this. 