### PR TITLE
added method to expose gravity control.

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -152,7 +152,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * Set bottom gravity
      * If the value is negative it will be set to default value.
      */
-    fun setGravity(y:Float): ParticleSystem {
+    fun setGravity(y: Float): ParticleSystem {
         gravity.y = if (y < 0) 0.01f else y
         return this
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -8,6 +8,7 @@ import nl.dionsegijn.konfetti.emitters.StreamEmitter
 import nl.dionsegijn.konfetti.models.ConfettiConfig
 import nl.dionsegijn.konfetti.models.Shape
 import nl.dionsegijn.konfetti.models.Size
+import nl.dionsegijn.konfetti.models.Vector
 import nl.dionsegijn.konfetti.modules.LocationModule
 import nl.dionsegijn.konfetti.modules.VelocityModule
 import java.util.Random
@@ -153,7 +154,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * If the value is negative it will be set to default value.
      */
     fun setGravity(y: Float): ParticleSystem {
-        gravity.y = if (y < 0) 0.01f else y
+        gravity.y = y.coerceAtLeast(0.01f)
         return this
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -28,6 +28,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     private var sizes = arrayOf(Size(16))
     private var shapes: Array<Shape> = arrayOf(Shape.Square)
     private var confettiConfig = ConfettiConfig()
+    private var gravity = Vector(0f, 0.01f)
 
     fun getDelay() = confettiConfig.delay
 
@@ -144,6 +145,15 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      */
     fun setMaxAcceleration(maxAcceleration: Float): ParticleSystem {
         velocity.maxAcceleration = maxAcceleration / 10
+        return this
+    }
+
+    /**
+     * Set bottom gravity
+     * If the value is negative it will be set to default value.
+     */
+    fun setGravity(y:Float): ParticleSystem {
+        gravity.y = if (y < 0) 0.01f else y
         return this
     }
 
@@ -285,7 +295,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      * By calling this function the system will start rendering confetti
      */
     private fun startRenderSystem(emitter: Emitter) {
-        renderSystem = RenderSystem(location, velocity, sizes, shapes, colors, confettiConfig, emitter)
+        renderSystem = RenderSystem(location, velocity, gravity, sizes, shapes, colors, confettiConfig, emitter)
         start()
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -19,6 +19,7 @@ import java.util.Random
 class RenderSystem(
     private val location: LocationModule,
     private val velocity: VelocityModule,
+    private val gravity: Vector,
     private val sizes: Array<Size>,
     private val shapes: Array<Shape>,
     private val colors: IntArray,
@@ -33,7 +34,6 @@ class RenderSystem(
     var enabled = true
 
     private val random = Random()
-    private var gravity = Vector(0f, 0.01f)
     private val particles: MutableList<Confetti> = mutableListOf()
 
     init {


### PR DESCRIPTION
Hey @DanielMartinus 

added method to expose vertical/bottom gravity control. I think this would be helpful in controlling the momentum of the confettis with higher speeds, so that they don't just jump out of screen, when burst in upward direction. Kept the defaults same.

I'm also thinking to work on gravity control on x-axis, to allow change in gravity direction as well. let me know what you think. 