### PR TITLE
make speed density independent

### DIFF
--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -24,6 +24,7 @@ class Confetti(
     val rotationSpeedMultiplier: Float = 1f
 ) {
 
+    private val density = Resources.getSystem().displayMetrics.density
     private val mass = size.mass
     private var width = size.sizeInPx
     private val paint: Paint = Paint()
@@ -38,7 +39,7 @@ class Confetti(
     private var alpha: Int = 255
 
     init {
-        val minRotationSpeed = 0.29f * Resources.getSystem().displayMetrics.density
+        val minRotationSpeed = 0.29f * density
         val maxRotationSpeed = minRotationSpeed * 3
         if (rotate) {
             rotationSpeed = (maxRotationSpeed * Random.nextFloat() + minRotationSpeed) * rotationSpeedMultiplier
@@ -64,7 +65,7 @@ class Confetti(
             velocity.add(acceleration)
         }
 
-        location.addScaled(velocity, deltaTime * speedF)
+        location.addScaled(velocity, deltaTime * speedF * density)
 
         if (lifespan <= 0) updateAlpha(deltaTime)
         else lifespan -= (deltaTime * 1000).toLong()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -22,7 +22,7 @@ class Confetti(
     val accelerate: Boolean = true,
     val maxAcceleration: Float = -1f,
     val rotationSpeedMultiplier: Float = 1f,
-    val speedDensityIndependent: Boolean = false
+    val speedDensityIndependent: Boolean = true
 ) {
 
     private val density = Resources.getSystem().displayMetrics.density

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/Confetti.kt
@@ -21,7 +21,8 @@ class Confetti(
     val rotate: Boolean = true,
     val accelerate: Boolean = true,
     val maxAcceleration: Float = -1f,
-    val rotationSpeedMultiplier: Float = 1f
+    val rotationSpeedMultiplier: Float = 1f,
+    val speedDensityIndependent: Boolean = false
 ) {
 
     private val density = Resources.getSystem().displayMetrics.density
@@ -65,7 +66,11 @@ class Confetti(
             velocity.add(acceleration)
         }
 
-        location.addScaled(velocity, deltaTime * speedF * density)
+        if (speedDensityIndependent) {
+            location.addScaled(velocity, deltaTime * speedF * density)
+        } else {
+            location.addScaled(velocity, deltaTime * speedF)
+        }
 
         if (lifespan <= 0) updateAlpha(deltaTime)
         else lifespan -= (deltaTime * 1000).toLong()

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -122,7 +122,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     }
 
     /**
-     * Set the speed of the particle
+     * Set the speed of the particle in dip per second
      * If value is negative it will be automatically set to 0
      */
     fun setSpeed(speed: Float): ParticleSystem {
@@ -131,7 +131,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     }
 
     /**
-     * Set the speed range of the particle
+     * Set the speed range of the particle in dip per second
      * If one of the values is negative it will be automatically set to 0
      */
     fun setSpeed(minSpeed: Float, maxSpeed: Float): ParticleSystem {

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -122,7 +122,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     }
 
     /**
-     * Set the speed of the particle in dip per second
+     * Set the speed of the particle
      * If value is negative it will be automatically set to 0
      */
     fun setSpeed(speed: Float): ParticleSystem {
@@ -131,7 +131,7 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
     }
 
     /**
-     * Set the speed range of the particle in dip per second
+     * Set the speed range of the particle
      * If one of the values is negative it will be automatically set to 0
      */
     fun setSpeed(minSpeed: Float, maxSpeed: Float): ParticleSystem {
@@ -189,6 +189,14 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
      */
     fun setAccelerationEnabled(enabled: Boolean): ParticleSystem {
         confettiConfig.accelerate = enabled
+        return this
+    }
+
+    /**
+     * Account for pixel density so that confetti move consistently across all devices.
+     */
+    fun setSpeedDensityIndependent(independent: Boolean): ParticleSystem {
+        confettiConfig.speedDensityIndependent = independent
         return this
     }
 

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/ParticleSystem.kt
@@ -194,6 +194,8 @@ class ParticleSystem(private val konfettiView: KonfettiView) {
 
     /**
      * Account for pixel density so that confetti move consistently across all devices.
+     * When true confetti will move in dip / second.
+     * When false confetti will move in pixels / second.
      */
     fun setSpeedDensityIndependent(independent: Boolean): ParticleSystem {
         confettiConfig.speedDensityIndependent = independent

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/emitters/RenderSystem.kt
@@ -53,7 +53,8 @@ class RenderSystem(
                 rotate = config.rotate,
                 maxAcceleration = velocity.maxAcceleration,
                 accelerate = config.accelerate,
-                rotationSpeedMultiplier = velocity.getRotationSpeedMultiplier()
+                rotationSpeedMultiplier = velocity.getRotationSpeedMultiplier(),
+                speedDensityIndependent = config.speedDensityIndependent
             )
         )
     }

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
@@ -9,5 +9,6 @@ data class ConfettiConfig(
     var timeToLive: Long = 2000L,
     var rotate: Boolean = true,
     var accelerate: Boolean = true,
-    var delay: Long = 0L
+    var delay: Long = 0L,
+    var speedDensityIndependent: Boolean = false
 )

--- a/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
+++ b/konfetti/src/main/java/nl/dionsegijn/konfetti/models/ConfettiConfig.kt
@@ -10,5 +10,5 @@ data class ConfettiConfig(
     var rotate: Boolean = true,
     var accelerate: Boolean = true,
     var delay: Long = 0L,
-    var speedDensityIndependent: Boolean = false
+    var speedDensityIndependent: Boolean = true
 )


### PR DESCRIPTION
Hi @DanielMartinus!

I noticed in my project that devices with low pixel density had much higher particle velocity than I had developed for and realized that this is because velocity is in terms of pixels and not dip in the library. Here is a comparison between 5 inch ldpi and xxhdpi devices with no change on the simple demo:

LDPI: ![ldpi-before](https://user-images.githubusercontent.com/16960319/108793793-652abd80-7552-11eb-8a68-7d5c099c76c5.gif) XXHDPI: ![xxhdpi-before](https://user-images.githubusercontent.com/16960319/108793107-c9e51880-7550-11eb-84f3-df625d05b6a3.gif)


as you can see the particles on the ldpi device are traveling 4x as fast as the xxhdpi device. Here is a comparison after the change:


LDPI: ![ldpi-after](https://user-images.githubusercontent.com/16960319/108793312-3fe97f80-7551-11eb-95fa-7cfc53b0b8e3.gif) XXHDPI: ![xxhdpi-after](https://user-images.githubusercontent.com/16960319/108793325-48da5100-7551-11eb-9a38-0f42ccd595f9.gif)


I would expect that velocity remaining constant across pixel densities is desired behavior, but if you think that some might not want this I would be happy to update the PR so that this is an option passed to the particle system (something like `setSpeedPixelIndependent()`).  Thanks for the great library!
