### PR TITLE
Depend on library projects rather than published artifacts

### DIFF
--- a/konfetti/compose/build.gradle
+++ b/konfetti/compose/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    api project(':konfetti:core')
+    api project(':konfetti:konfetti-core')
 
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/konfetti/compose/build.gradle
+++ b/konfetti/compose/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
+    api project(':konfetti:core')
 
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/konfetti/core/build.gradle
+++ b/konfetti/core/build.gradle
@@ -56,7 +56,6 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/konfetti/xml/build.gradle
+++ b/konfetti/xml/build.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    api project(':konfetti:core')
+    api project(':konfetti:konfetti-core')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/konfetti/xml/build.gradle
+++ b/konfetti/xml/build.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
+    api project(':konfetti:core')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/samples/shared/build.gradle
+++ b/samples/shared/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation 'nl.dionsegijn:konfetti-core:2.0.1'
+    implementation project(':konfetti:core')
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'

--- a/samples/shared/build.gradle
+++ b/samples/shared/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation project(':konfetti:core')
+    implementation project(':konfetti:konfetti-core')
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
 include ':samples:compose-kotlin', ':samples:xml-kotlin', ':samples:xml-java', ':samples:shared'
 include ':konfetti:xml', ':konfetti:compose', ':konfetti:core'
+
+findProject(':konfetti:core').name = 'konfetti-core'


### PR DESCRIPTION
This allows the sample apps to be used to test changes to the libraries without needing to publish