### PR TITLE
Setup core transitive dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 buildscript {
+    ext.konfetti_version = '2.0.1'
     ext.kotlin_version = '1.6.0'
     ext.compose_version = '1.1.0-rc01'
     ext.coroutines_version = '1.4.2'

--- a/konfetti/compose/build.gradle
+++ b/konfetti/compose/build.gradle
@@ -63,7 +63,8 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
+    debugApi project(path: ':konfetti:core')
+    releaseApi "nl.dionsegijn:konfetti-core:$konfetti_version"
 
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/konfetti/compose/build.gradle
+++ b/konfetti/compose/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'nl.dionsegijn'
-    PUBLISH_VERSION = "2.0.1"
+    PUBLISH_VERSION = konfetti_version
     PUBLISH_ARTIFACT_ID = 'konfetti-compose'
 }
 

--- a/konfetti/core/build.gradle
+++ b/konfetti/core/build.gradle
@@ -56,7 +56,6 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/konfetti/core/build.gradle
+++ b/konfetti/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'nl.dionsegijn'
-    PUBLISH_VERSION = "2.0.1"
+    PUBLISH_VERSION = konfetti_version
     PUBLISH_ARTIFACT_ID = 'konfetti-core'
 }
 

--- a/konfetti/xml/build.gradle
+++ b/konfetti/xml/build.gradle
@@ -52,7 +52,9 @@ android {
 }
 
 dependencies {
-    api 'nl.dionsegijn:konfetti-core:2.0.1'
+    debugApi project(path: ':konfetti:core')
+    releaseApi "nl.dionsegijn:konfetti-core:$konfetti_version"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/konfetti/xml/build.gradle
+++ b/konfetti/xml/build.gradle
@@ -4,7 +4,7 @@ apply plugin: "com.diffplug.spotless"
 
 ext {
     PUBLISH_GROUP_ID = 'nl.dionsegijn'
-    PUBLISH_VERSION = "2.0.1"
+    PUBLISH_VERSION = konfetti_version
     PUBLISH_ARTIFACT_ID = 'konfetti-xml'
 }
 


### PR DESCRIPTION
This PR does two things: 

- When developing the local core module is used to developer against the latest changes of core. 
- When publishing `konfetti-xml` and `konfetti-compose` the core module is pulled from the remote Maven repository. This way the pom refers to a remote copy of `konfetti-core` so that it works as a transitive dependency.

This is a follow-up on https://github.com/DanielMartinus/Konfetti/pull/290.

When building a release the core module needs to be pulled from the remote maven repository so that it can be included in the pom file. Other option was using `fat aar` to include core's files. Though what I read is that maintaining fat aar can be lots of work. One downside of this solution is that core always needs to be published first before publishing `konfetti-xml` and `konfetti-compose`.