### PR TITLE
fix alpha on DrawableShape, on compose: add parameter to apply alpha or not

### DIFF
--- a/.github/workflows/ci-konfetti.yaml
+++ b/.github/workflows/ci-konfetti.yaml
@@ -20,4 +20,4 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run build and checks
-        run: ./gradlew build
+        run: ./gradlew buildDebug

--- a/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/DrawShapes.kt
+++ b/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/DrawShapes.kt
@@ -57,7 +57,7 @@ fun Shape.draw(drawScope: DrawScope, particle: Particle, imageResource: ImageBit
                     } else {
                         drawable.setColorFilter(particle.color, PorterDuff.Mode.SRC_IN)
                     }
-                } else {
+                } else if(applyAlpha) {
                     drawable.alpha = (particle.alpha shl 24) or (particle.color and 0xffffff)
                 }
 

--- a/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/DrawShapes.kt
+++ b/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/DrawShapes.kt
@@ -57,7 +57,7 @@ fun Shape.draw(drawScope: DrawScope, particle: Particle, imageResource: ImageBit
                     } else {
                         drawable.setColorFilter(particle.color, PorterDuff.Mode.SRC_IN)
                     }
-                } else if(applyAlpha) {
+                } else if (applyAlpha) {
                     drawable.alpha = (particle.alpha shl 24) or (particle.color and 0xffffff)
                 }
 

--- a/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/models/Shape.kt
+++ b/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/models/Shape.kt
@@ -21,7 +21,7 @@ sealed interface Shape {
      * A drawable shape
      * @param drawable drawable
      * @param tint Set to `false` to opt out of tinting the drawable, keeping its original colors.
-     * @param applyAlpha if tint is `false` then apply alpha or not on drawable
+     * @param applyAlpha Set to false to not apply alpha to drawables
      */
     data class DrawableShape(
         val drawable: Drawable,

--- a/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/models/Shape.kt
+++ b/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/models/Shape.kt
@@ -16,10 +16,17 @@ sealed interface Shape {
             require(heightRatio in 0f..1f)
         }
     }
+
+    /**
+     * A drawable shape
+     * @param drawable drawable
+     * @param tint Set to `false` to opt out of tinting the drawable, keeping its original colors.
+     * @param applyAlpha if tint is `false` then apply alpha or not on drawable
+     */
     data class DrawableShape(
         val drawable: Drawable,
-        /** Set to `false` to opt out of tinting the drawable, keeping its original colors. */
-        val tint: Boolean = true
+        val tint: Boolean = true,
+        val applyAlpha: Boolean = true,
     ) : Shape {
         val heightRatio =
             if (drawable.intrinsicHeight == -1 && drawable.intrinsicWidth == -1) {

--- a/konfetti/xml/src/main/java/nl/dionsegijn/konfetti/xml/DrawShapes.kt
+++ b/konfetti/xml/src/main/java/nl/dionsegijn/konfetti/xml/DrawShapes.kt
@@ -38,7 +38,7 @@ fun Shape.draw(canvas: Canvas, paint: Paint, size: Float) {
                 } else {
                     drawable.setColorFilter(paint.color, PorterDuff.Mode.SRC_IN)
                 }
-            } else {
+            } else if (applyAlpha) {
                 drawable.alpha = paint.alpha
             }
 

--- a/samples/xml-java/src/main/java/nl/dionsegijn/xml/java/MainActivity.java
+++ b/samples/xml-java/src/main/java/nl/dionsegijn/xml/java/MainActivity.java
@@ -32,7 +32,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         final Drawable drawable = ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_heart);
-        drawableShape = new Shape.DrawableShape(drawable, true);
+        drawableShape = new Shape.DrawableShape(drawable, true, true);
 
         konfettiView = findViewById(R.id.konfettiView);
         EmitterConfig emitterConfig = new Emitter(5L, TimeUnit.SECONDS).perSecond(50);


### PR DESCRIPTION
Alpha on `DrawableShape` not had same behavior between Compose and XML View.

I used same parameter:
```
Party(
                    speed = 0f,
                    maxSpeed = 10f,
                    damping = 1f,
                    spread = 360,
                    size = listOf(Size(sizeInDp = 20, mass = 8f)),
                    shapes = listOf(
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_yellow_2)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_purple_1)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_purple_3)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_green_1)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_blue_1)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_red_2)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_purple_4)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_blue_2)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_red_1)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_yellow_1)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_purple_2)!!, false),
                        Shape.DrawableShape(AppCompatResources.getDrawable(context,R.drawable.img_conf_green_2)!!, false),

                        ),
                    emitter = Emitter(duration = 100, TimeUnit.MILLISECONDS).max(100),
                    position = Position.Relative(0.5, 0.3)
                )
```

And here the result:
[confetti-xml-kotlin.webm](https://github.com/DanielMartinus/Konfetti/assets/7816190/5a4bb766-5e16-4b56-b275-455f2bf5e498)
[confetti-compose.webm](https://github.com/DanielMartinus/Konfetti/assets/7816190/4a8197d9-a5b9-4d5c-ae70-f081e0ca5237)

I think is same issue as https://github.com/DanielMartinus/Konfetti/issues/298

I could use a sealed interface instead of new boolean parameter but it  break compatibility with older version:
```
data class DrawableShape(
        val drawable: Drawable,
        val transformation: DrawableShapeTransformation = DrawableShapeTransformation.Tint,
    ) : Shape {
        ...
    }


sealed interface DrawableShapeTransformation {
    object Tint : DrawableShapeTransformation
    object Alpha : DrawableShapeTransformation
    object None : DrawableShapeTransformation
}
```
