### PR TITLE
Use dynamic frameRate instead of locking to 60fps

### DIFF
--- a/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/emitter/Confetti.kt
+++ b/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/emitter/Confetti.kt
@@ -37,7 +37,7 @@ class Confetti(
     private var rotationWidth = width
 
     // Expected frame rate
-    private var speedF = 60f
+    private var frameRate = 60f
     private var gravity = Vector(0f, 0.02f)
 
     var alpha: Int = 255
@@ -68,6 +68,9 @@ class Confetti(
     }
 
     private fun update(deltaTime: Float, drawArea: Rect) {
+        // Calculate frameRate dynamically, fallback to 60fps in case deltaTime is 0
+        frameRate = if (deltaTime > 0) 1f / deltaTime else 60f
+
         if (location.y > drawArea.height()) {
             alpha = 0
             return
@@ -76,18 +79,18 @@ class Confetti(
         velocity.add(acceleration)
         velocity.mult(damping)
 
-        location.addScaled(velocity, deltaTime * speedF * pixelDensity)
+        location.addScaled(velocity, deltaTime * frameRate * pixelDensity)
 
         lifespan -= (deltaTime * 1000).toLong()
         if (lifespan <= 0) updateAlpha(deltaTime)
 
         // 2D rotation around the center of the confetti
-        rotation += rotationSpeed2D * deltaTime * speedF
+        rotation += rotationSpeed2D * deltaTime * frameRate
         if (rotation >= 360) rotation = 0f
 
         // 3D rotation effect by decreasing the width and make sure that rotationSpeed is always
         // positive by using abs
-        rotationWidth -= abs(rotationSpeed3D) * deltaTime * speedF
+        rotationWidth -= abs(rotationSpeed3D) * deltaTime * frameRate
         if (rotationWidth < 0) rotationWidth = width
 
         scaleX = abs(rotationWidth / width - 0.5f) * 2
@@ -98,7 +101,7 @@ class Confetti(
 
     private fun updateAlpha(deltaTime: Float) {
         alpha = if (fadeOut) {
-            val interval = 5 * deltaTime * speedF
+            val interval = 5 * deltaTime * frameRate
             (alpha - interval.toInt()).coerceAtLeast(0)
         } else {
             0

--- a/konfetti/xml/src/main/java/nl/dionsegijn/konfetti/xml/DrawShapes.kt
+++ b/konfetti/xml/src/main/java/nl/dionsegijn/konfetti/xml/DrawShapes.kt
@@ -6,14 +6,12 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.os.Build
-import nl.dionsegijn.konfetti.core.Particle
 import nl.dionsegijn.konfetti.core.models.Shape
 import nl.dionsegijn.konfetti.core.models.Shape.Circle
 import nl.dionsegijn.konfetti.core.models.Shape.Circle.rect
 import nl.dionsegijn.konfetti.core.models.Shape.DrawableShape
 import nl.dionsegijn.konfetti.core.models.Shape.Rectangle
 import nl.dionsegijn.konfetti.core.models.Shape.Square
-import nl.dionsegijn.konfetti.core.models.Shape.Text
 
 /**
  * Draw a shape to `canvas`. Implementations are expected to draw within a square of size


### PR DESCRIPTION
Updated the variable `speedF` to `frameRate` to better reflect what it does.

Before this variable was locked to 60fps. This variable is used to scale the particles movements (and other properties) based on the frame rate, this explains why it's moving two times slower on 120fps and probably two times faster on 30fps.

This value is now updated based on the deltaTime (time between frames) to account for different frame rates.

Fixes #314