### PR TITLE
Use SPDX license name

### DIFF
--- a/scripts/publish-module.gradle.kts
+++ b/scripts/publish-module.gradle.kts
@@ -61,8 +61,9 @@ afterEvaluate {
 
                     licenses {
                         license {
-                            name.set("Konfetti License")
+                            name.set("ISC")
                             url.set("https://github.com/DanielMartinus/Konfetti/blob/main/LICENSE")
+                            distribution.set("repo")
                         }
                     }
 


### PR DESCRIPTION
Maven is not able to detect that the license being used by Konfetti is ISC. Per recommendation from Maven, the SPDX license name should be used (https://maven.apache.org/pom.html#Licenses)

```
Using an [SPDX identifier](https://spdx.org/licenses/) as the license name is recommended
```

The SPDX identifier of the ISC license is just ISC.

