### PR TITLE
Reset frame time when Composable's lifecycle is resumed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ core-ktx = "1.7.0"
 appcompat = "1.4.0"
 constraintlayout = "2.1.3"
 activity-compose = "1.4.0"
-androidx-lifecycle = "1.4.0"
+androidx-lifecycle = "2.8.7"
 espresso = "3.5.1"
 tracing = "1.1.0"
 material = "1.4.0"
@@ -26,6 +26,7 @@ androidx-tracing = { group = "androidx.tracing", name = "tracing", version.ref =
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "appcompat" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 test-mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }

--- a/konfetti/compose/build.gradle.kts
+++ b/konfetti/compose/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     implementation(libs.compose.foundation)
     implementation(libs.compose.ui)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 
     testImplementation(libs.test.junit)
     androidTestImplementation(libs.test.junit.ext)

--- a/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/KonfettiView.kt
+++ b/konfetti/compose/src/main/java/nl/dionsegijn/konfetti/compose/KonfettiView.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import nl.dionsegijn.konfetti.core.Particle
 import nl.dionsegijn.konfetti.core.Party
 import nl.dionsegijn.konfetti.core.PartySystem
@@ -49,6 +51,9 @@ fun KonfettiView(
      */
     val imageStore = remember { ImageStore() }
 
+    LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
+        frameTime.value = 0L
+    }
     LaunchedEffect(Unit) {
         partySystems =
             parties.map {


### PR DESCRIPTION
This prevents the delta from the previous frame time til now being so large that we render an inordinate amount of particles, slowing down or even crashing the app by running out of memory. A very similar issue as fixed in: https://github.com/DanielMartinus/Konfetti/pull/289