### PR TITLE
Update GitHub Actions cache step version

### DIFF
--- a/.github/workflows/ci-konfetti.yaml
+++ b/.github/workflows/ci-konfetti.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
V2 was deprecated and no longer downloading.

One step further would be to use [setup-gradle](https://github.com/gradle/actions) as that would handle the cache for us, but this is the minimum change required to get things moving again. Can open a PR for that change as well if you want @DanielMartinus.