### PR TITLE
Use SPDX id for license name

### DIFF
--- a/scripts/publish-module.gradle.kts
+++ b/scripts/publish-module.gradle.kts
@@ -61,8 +61,7 @@ afterEvaluate {
 
                     licenses {
                         license {
-                            name.set("Konfetti License")
-                            url.set("https://github.com/DanielMartinus/Konfetti/blob/main/LICENSE")
+                            name.set("ISC")
                         }
                     }
 


### PR DESCRIPTION
The current URL (https://github.com/DanielMartinus/Konfetti/blob/main/LICENSE) doesn't work with [Licensee](https://github.com/cashapp/licensee) without explicitly allowing it, and it would be nice to use a standardized URL.

See https://github.com/cashapp/licensee/issues/137