### PR TITLE
Fixed inaccurate generated count and potential OOM caused by infinite loop due to division by zero.

### DIFF
--- a/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/emitter/EmitterConfig.kt
+++ b/konfetti/core/src/main/java/nl/dionsegijn/konfetti/core/emitter/EmitterConfig.kt
@@ -42,7 +42,7 @@ class EmitterConfig(
      * Amount of particles created over the duration that is set
      */
     fun max(amount: Int): EmitterConfig {
-        this.amountPerMs = (emittingTime / amount) / 1000f
+        this.amountPerMs = (emittingTime / amount.toFloat()) / 1000f
         return this
     }
 


### PR DESCRIPTION
example:
start(Party(emitter = Emitter(100, TimeUnit.MILLISECONDS).max(101)))